### PR TITLE
Propose standard package commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ It consists of a command line tool and wrapper which provides an common interfac
    
 where command is one of:
 
-    plot # Display results using e.g. matplotlib
-    netcdf # Write the results to a netcdf file
-    json # Write the result to a json file
+1. `run`: a generic command which will simply run the analysis. Useful when analysis is complicated and it's more natural to write results and plots to file at the same time.
+2. `plot`: display results to screen or save them to an image file.
+3. `write`: write the results to a file (NetCDF, JSON, CSV) specified by command line argument or decided by package.
+4. `return`: return a dict of results for further manipulation.
    
 Options are package specific, with the following exceptions:
 
@@ -29,14 +30,5 @@ Each separate package within gs2pp defines the following standard function
 
     def gs2pp_interface( command, package_function, options ):
 
-The parameters `command` and `package_function` are strings, and options is a dict. This function must return different things according to the value of command:
-
-- `plot` an object which implements `plot` function and overloads the `+` operator
-- `json` a json object (TBC)
-- `netcdf` unspecified: in this case the subpackage writes the netcdf file itself
-
-
-## CodeRunner Integration
-
-The CodeRunner gs2 module will use the RubyPython bridge to access `gs2pp` via the wrapper. This will allow the functionality of `gs2pp` to be applied and combined across multiple gs2 runs managed by `coderunner`.
+The parameters `command` and `package_function` are strings, and options is a dict. This function must do different things according to the value of `command`.
 

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Each separate package within gs2pp defines the following standard function
 
     def gs2pp_interface( command, package_function, options ):
 
-The parameters `command` and `package_function` are strings, and options is a dict. This function must do different things according to the value of `command`.
+The parameters `command` and `package_function` are strings, and options is a dict. This function must do different things according to the value of `command`. The analysis package does *not* need to implement all `command` functions, only the ones which make sense for the package. The wrapper will handle exception handling to the user based on a (yet to be defined) way of getting the implemented methods from a given package.
 


### PR DESCRIPTION
I propose we have the following commands executed by a package: `plot`, `write`, `run`, `return` which do the things documented in the README.

Importantly, plot handles everything to do with plots and will display or save to file depending on an option, and `write` handles everything to do with output of results to file.
